### PR TITLE
Skip Huawei labels when NFD patches a default namespace

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/nodefeaturerules.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nodefeaturerules.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.nodefeaturerules }}
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: npu-test
+spec:
+  rules:
+    - name: "npu"
+      labels:
+        "host-arch": "huawei-arm"
+        "accelerator": "huawei-Ascend910"
+        "accelerator-type": "module-910b-8"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+              vendor: {op: In, value: ["10de"]}
+{{- end }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -1,9 +1,9 @@
 image:
-  repository: registry.k8s.io/nfd/node-feature-discovery
+  repository: docker.io/taenyang/node-feature-discovery
   # This should be set to 'IfNotPresent' for released version
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # tag, if defined will use the given image tag, else Chart.AppVersion will be used
-  # tag
+  tag: latest
 imagePullSecrets: []
 
 nameOverride: ""
@@ -482,3 +482,5 @@ topologyGC:
 tls:
   enable: false
   certManager: false
+
+nodefeaturerules : true

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1166,10 +1166,18 @@ func (m *nfdMaster) configure(filepath string, overrides string) error {
 
 // addNs adds a namespace if one isn't already found from src string
 func addNs(src string, nsToAdd string) string {
-	if strings.Contains(src, "/") {
+	if strings.Contains(src, "/") || containsHW(src) {
 		return src
 	}
 	return path.Join(nsToAdd, src)
+}
+
+// containsHW returns true if the label contains Huawei's keys
+func containsHW(src string) bool {
+	if strings.Contains(src, "accelerator") || src == "host-arch" {
+		return true
+	}
+	return false
 }
 
 // splitNs splits a name into its namespace and name parts


### PR DESCRIPTION
**改动说明**
在NFD执行对不含namespace的标签打上默认前缀时，跳过华为相关的标签
添加了自动对带有华为设备的节点打上相关标签的nodefeaturerules，此功能可以在values.yaml里关闭