### PR TITLE
Skip Huawei labels when NFD patches a default namespace

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/nodefeaturerules.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nodefeaturerules.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.nodefeaturerules }}
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: npu
+spec:
+  rules:
+    - name: "ascend/atlas-800t-a2-arm"
+      labels:
+        "node-role.kubernetes.io/worker": "worker"
+        "workerselector": "dls-worker-node"
+        "host-arch": "huawei-arm"
+        "accelerator": "huawei-Ascend910"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["19e5"]}
+            device: {op: In, value: ["d802"]}
+        - feature: kernel.config
+          matchExpressions:
+            X86: {op: In, value: ["n"]}
+    - name: "ascend/atlas-800t-a2-x86"
+      labels:
+        "node-role.kubernetes.io/worker": "worker"
+        "workerselector": "dls-worker-node"
+        "host-arch": "huawei-x86"
+        "accelerator": "huawei-Ascend910"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["19e5"]}
+            device: {op: In, value: ["d802"]}
+        - feature: kernel.config
+          matchExpressions:
+            X86: {op: In, value: ["y"]}
+{{- end }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -511,3 +511,5 @@ tls:
 prometheus:
   enable: false
   labels: {}
+
+nodefeaturerules: true

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1278,10 +1278,27 @@ func (m *nfdMaster) configure(filepath string, overrides string) error {
 
 // addNs adds a namespace if one isn't already found from src string
 func addNs(src string, nsToAdd string) string {
-	if strings.Contains(src, "/") {
+	if strings.Contains(src, "/") || containsHW(src) {
 		return src
 	}
 	return path.Join(nsToAdd, src)
+}
+
+// containsHW returns true if the label contains Huawei's keys
+func containsHW(src string) bool {
+	keys := []string{
+		"workerselector",
+		"host-arch",
+		"accelerator",
+		"accelerator-type",
+		"servertype",
+	}
+	for _, key := range keys {
+		if key == src {
+			return true
+		}
+	}
+	return false
 }
 
 // splitNs splits a name into its namespace and name parts


### PR DESCRIPTION
**改动说明**
在NFD执行对不含namespace的标签打上默认前缀时，跳过华为相关的标签
添加了自动对带有华为设备的节点打上相关标签的nodefeaturerules，此功能可以在values.yaml里关闭